### PR TITLE
Update argon2ds to argon2id

### DIFF
--- a/phc-sf-spec.md
+++ b/phc-sf-spec.md
@@ -301,7 +301,7 @@ For Argon2, the following is specified:
 
   - The identifier for Argon2i is `argon2i`.
 
-  - The identifier for Argon2ds is `argon2ds`.
+  - The identifier for Argon2id is `argon2id`.
 
   - The versions are: [16, 19].
   


### PR DESCRIPTION
"Argon2ds" is not mentioned in the Argon2 spec, and I note that `argon2id` was missing from this spec.